### PR TITLE
Speedup day7

### DIFF
--- a/apps/aoc/src/day7.erl
+++ b/apps/aoc/src/day7.erl
@@ -6,22 +6,12 @@ solve() ->
   solve(input()).
 
 solve(Input) ->
-  {348996, 98231647} = {part1(Input), part2(Input)}.
+  Part1 = calculate_fuel(floor(util:median(Input)), Input, fun(A) -> A end),
+  Part2 = calculate_fuel(ceil(util:mean(Input)) - 1, Input, fun termial/1),
+  {348996, 98231647} = {Part1, Part2}.
 
-part1(Input) ->
-  MinMax = lists:seq(lists:min(Input), lists:max(Input)),
-  calculate_fuel(MinMax, Input, fun(A) -> A end, []).
-
-part2(Input) ->
-  MinMax = lists:seq(lists:min(Input), lists:max(Input)),
-  F = fun termial/1,
-  calculate_fuel(MinMax, Input, F, []).
-
-calculate_fuel([], _Input, _F, Acc) ->
-  lists:min(Acc);
-calculate_fuel([H | T], Input, F, Acc) ->
-  FuelCost = do_calculate_fuel(H, Input, F, 0),
-  calculate_fuel(T, Input, F, [ FuelCost | Acc ]).
+calculate_fuel(H, Input, F) ->
+  round(do_calculate_fuel(H, Input, F, 0)).
 
 do_calculate_fuel(_Pos, [], _F, Acc) -> Acc;
 do_calculate_fuel(Pos, [H | T], F, Acc) ->

--- a/apps/aoc/src/util.erl
+++ b/apps/aoc/src/util.erl
@@ -5,6 +5,8 @@
         , read_file_fold/4
         , time_avg/2
         , time_avg/4
+        , median/1
+        , mean/1
         , binary_to_decimal/1
         , split_to_chunks/2
         ]).
@@ -44,6 +46,15 @@ binary_to_decimal(Binary) ->
 -spec split_to_chunks([any()], pos_integer()) -> [[any()], ...].
 split_to_chunks(L, N) when is_integer(N), N > 0 ->
   split_to_chunks(N, 0, L, []).
+
+median(Unsorted) ->
+  Sorted = lists:sort(Unsorted),
+  Length = length(Sorted),
+  Mid = Length div 2,
+  Rem = Length rem 2,
+  (lists:nth(Mid + Rem, Sorted) + lists:nth(Mid + 1, Sorted)) / 2.
+
+mean(L) -> lists:sum(L) / length(L).
 
 %%%_* Internal ================================================================
 -spec read(string()) -> {error, atom()} | {ok, binary()}.


### PR DESCRIPTION
New times:
```
1> perftest:test([ fun day7:solve/0 ], timer:seconds(5)).
Method                            Loops               Min               Max            Median           Average
empty loop    938554 *  500 = 469277000           0.002us           7.798us           0.002us           0.003us
day7:solve()     270 *   50 =     13500         306.620us         858.040us         351.580us         370.044us
```